### PR TITLE
Ensure when an error occurs we exit with a failure code

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -49,4 +49,5 @@ try {
     $convert->run();
 } catch (Exception $e) {
     echo $e->getMessage() . PHP_EOL;
+    exit(1);
 }


### PR DESCRIPTION
When running convert.php in a script, we need to detect failures. If an exception was thrown, we should exit with a non 0 exit status