### PR TITLE
added dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Run the script on your exported MediaWiki XML file:
                  (Default: false)
     --help     : This help message (almost)
 
+## Run with docker
+
+Create a new directory and put `filename.xml` into the new directory:
+```bash
+mkdir my_wiki
+mv filename.xml my_wiki/
+cd my_wiki
+```
+Now you can convert `filename.xml` using docker.
+Note: do **not** use the output parameter. The output will always be written into the subdirectory `output` of the current path. (hence the creation of a new directory). This is necessary, because the docker container does not have access to your filesystem except for the current directory (because of the `-v $PWD:/app` parameter for docker)
+```bash
+docker run -v $PWD:/app mediawiki-to-gfm --filename=filename.xml
+```
+
 ## Export Mediawiki Files to XML 
 
 In order to convert from MediaWiki format to GFM and use in GitLab (or GitHub), you will first need to export all the pages you wish to convert from Mediawiki into an XML file. Here are a few simple steps to help

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN set -eux ; \
     rm -f /tmp/installer.php ; \
     find /tmp -type d -exec chmod -v 1777 {} +
 
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ pandoc
+RUN apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing/ pandoc
 
 
 RUN git clone https://github.com/outofcontrol/mediawiki-to-gfm.git ; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,99 @@
+FROM php:8-alpine
+
+RUN set -eux ; \
+    apk -U add --no-cache --virtual .composer-rundeps \
+    bash \
+    coreutils \
+    git \
+    make \
+    openssh-client \
+    patch \
+    subversion \
+    tini \
+    unzip \
+    zip \
+    $([ "$(apk --print-arch)" != "x86" ] && echo mercurial) \
+    $([ "$(apk --print-arch)" != "armhf" ] && echo p7zip)
+
+RUN printf "# composer php cli ini settings\n\
+    date.timezone=UTC\n\
+    memory_limit=-1\n\
+    " > $PHP_INI_DIR/php-cli.ini
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_HOME /tmp
+ENV COMPOSER_VERSION 2.3.10
+
+RUN set -eux ; \
+    # install https://github.com/mlocati/docker-php-extension-installer
+    curl \
+    --silent \
+    --fail \
+    --location \
+    --retry 3 \
+    --output /usr/local/bin/install-php-extensions \
+    --url https://github.com/mlocati/docker-php-extension-installer/releases/download/1.2.58/install-php-extensions \
+    ; \
+    echo 182011b3dca5544a70fdeb587af44ed1760aa9a2ed37d787d0f280a99f92b008e638c37762360cd85583830a097665547849cb2293c4a0ee32c2a36ef7a349e2 /usr/local/bin/install-php-extensions | sha512sum --strict --check ; \
+    chmod +x /usr/local/bin/install-php-extensions ; \
+    # install necessary/useful extensions not included in base image
+    install-php-extensions \
+    bz2 \
+    zip \
+    ; \
+    # install public keys for snapshot and tag validation, see https://composer.github.io/pubkeys.html
+    curl \
+    --silent \
+    --fail \
+    --location \
+    --retry 3 \
+    --output /tmp/keys.dev.pub \
+    --url https://raw.githubusercontent.com/composer/composer.github.io/e7f28b7200249f8e5bc912b42837d4598c74153a/snapshots.pub \
+    ; \
+    echo 572b963c4b7512a7de3c71a788772440b1996d918b1d2b5354bf8ba2bb057fadec6f7ac4852f2f8a8c01ab94c18141ce0422aec3619354b057216e0597db5ac2 /tmp/keys.dev.pub | sha512sum --strict --check ; \
+    curl \
+    --silent \
+    --fail \
+    --location \
+    --retry 3 \
+    --output /tmp/keys.tags.pub \
+    --url https://raw.githubusercontent.com/composer/composer.github.io/e7f28b7200249f8e5bc912b42837d4598c74153a/releases.pub \
+    ; \
+    echo 47f374b8840dcb0aa7b2327f13d24ab5f6ae9e58aa630af0d62b3d0ea114f4a315c5d97b21dcad3c7ffe2f0a95db2edec267adaba3f4f5a262abebe39aed3a28 /tmp/keys.tags.pub | sha512sum --strict --check ; \
+    # download installer.php, see https://getcomposer.org/download/
+    curl \
+    --silent \
+    --fail \
+    --location \
+    --retry 3 \
+    --output /tmp/installer.php \
+    --url https://raw.githubusercontent.com/composer/getcomposer.org/f24b8f860b95b52167f91bbd3e3a7bcafe043038/web/installer \
+    ; \
+    echo 3137ad86bd990524ba1dedc2038309dfa6b63790d3ca52c28afea65dcc2eaead16fb33e9a72fd2a7a8240afaf26e065939a2d472f3b0eeaa575d1e8648f9bf19 /tmp/installer.php | sha512sum --strict --check ; \
+    # install composer phar binary
+    php /tmp/installer.php \
+    --no-ansi \
+    --install-dir=/usr/bin \
+    --filename=composer \
+    --version=${COMPOSER_VERSION} \
+    ; \
+    composer --ansi --version --no-interaction ; \
+    composer diagnose ; \
+    rm -f /tmp/installer.php ; \
+    find /tmp -type d -exec chmod -v 1777 {} +
+
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ pandoc
+
+
+RUN git clone https://github.com/outofcontrol/mediawiki-to-gfm.git ; \
+    cd mediawiki-to-gfm ; \
+    composer update --no-dev ; \
+    ln -s $(pwd)/convert.php /usr/bin
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["convert.php"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker image build -t mediawiki-to-gfm  -f Dockerfile .

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+isCommand() {
+  # Retain backwards compatibility with common CI providers,
+  # see: https://github.com/composer/docker/issues/107
+  if [ "$1" = "sh" ]; then
+    return 1
+  fi
+
+  convert.php --help
+}
+mkdir -p /app/output
+# check if the first argument passed in looks like a flag
+if [ "${1#-}" != "$1" ]; then
+  set -- /sbin/tini -- convert.php "$@" --output=/app/output
+# check if the first argument passed in is composer
+elif [ "$1" = 'convert.php' ]; then
+  set -- /sbin/tini -- "$@" --output=/app/output
+# check if the first argument passed in matches a known command
+elif isCommand "$1"; then
+  set -- /sbin/tini -- convert.php "$@" --output=/app/output
+fi
+
+exec "$@"

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+DOCKER_USERNAME=outofcontrol
+docker tag mediawiki-to-gfm $DOCKER_USERNAME/mediawiki-to-gfm
+docker push $DOCKER_USERNAME/mediawiki-to-gfm
+echo "now create a version tag and push that one:"
+echo "docker tag mediawiki-to-gfm $DOCKER_USERNAME/mediawiki-to-gfm:version-1.0.1"
+echo "docker push $DOCKER_USERNAME/mediawiki-to-gfm:version-1.0.1"


### PR DESCRIPTION
## Summary
added a dockerfile that enables executing [mediawiki-to-gfm](https://github.com/outofcontrol/mediawiki-to-gfm) via docker.

## Motivation
For users like me who don't already have php, composer and pandoc installed (but have access to a machine with docker installed), it will be very useful, to run [mediawiki-to-gfm](https://github.com/outofcontrol/mediawiki-to-gfm) via docker.

## Usage

Create a new directory and put `filename.xml` into the new directory:
```bash
mkdir my_wiki
mv filename.xml my_wiki/
cd my_wiki
```
Now you can convert `filename.xml` using docker.
Note: do **not** use the output parameter. The output will always be written into the subdirectory `output` of the current path. (hence the creation of a new directory). This is necessary, because the docker container does not have access to your filesystem except for the current directory (because of the `-v $PWD:/app` parameter for docker)
```bash
docker run -v $PWD:/app thawn/mediawiki-to-gfm --filename=filename.xml
```

Note: in `Readme.md` I did not specify a username for the docker hub. I suggest you use your own account, so that you can push new images when you release new versions. I recommend to use a github workflow to automate that.
In push.sh I already specified the username outofcontrol.

I would also be fine with using my docker account for now, but I cannot promise to release updated versions quickly.